### PR TITLE
Upgrade Package to Elm 0.18

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,5 @@ node_js:
   - "node"
 install:
   - npm install -g elm
+  - npm install -g elm-test
 script: sh ./scripts/test.sh

--- a/elm-package.json
+++ b/elm-package.json
@@ -10,8 +10,8 @@
         "HttpBuilder"
     ],
     "dependencies": {
-        "elm-lang/core": "4.0.0 <= v < 5.0.0",
-        "evancz/elm-http": "3.0.1 <= v < 4.0.0"
+        "elm-lang/core": "5.0.0 <= v < 6.0.0",
+        "elm-lang/http": "1.0.0 <= v < 2.0.0"
     },
-    "elm-version": "0.17.0 <= v < 0.18.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/scripts/unit_tests.sh
+++ b/scripts/unit_tests.sh
@@ -1,4 +1,3 @@
 cd ./tests/unit;
 elm-package install -y
-elm-make ./TestRunner.elm --output ./tests.js;
-node ./tests.js;
+elm-test ./TestRunner.elm

--- a/tests/unit/TestRunner.elm
+++ b/tests/unit/TestRunner.elm
@@ -1,9 +1,13 @@
-module Main exposing (..)
+port module Main exposing (..)
 
-import ElmTest exposing (..)
 import Tests
+import Test.Runner.Node exposing (run, TestProgram)
+import Json.Encode exposing (Value)
 
 
-main : Program Never
+main : TestProgram
 main =
-    runSuite Tests.all
+    run emit Tests.all
+
+
+port emit : ( String, Value ) -> Cmd msg

--- a/tests/unit/elm-package.json
+++ b/tests/unit/elm-package.json
@@ -10,9 +10,10 @@
     "exposed-modules": [],
     "native-modules": true,
     "dependencies": {
-        "elm-community/elm-test": "1.1.0 <= v < 2.0.0",
-        "elm-lang/core": "4.0.0 <= v < 5.0.0",
-        "evancz/elm-http": "3.0.1 <= v < 4.0.0"
+        "elm-community/elm-test": "3.0.0 <= v < 4.0.0",
+        "rtfeldman/node-test-runner": "3.0.0 <= v < 4.0.0",
+        "elm-lang/core": "5.0.0 <= v < 6.0.0",
+        "elm-lang/http": "1.0.0 <= v < 2.0.0"
     },
-    "elm-version": "0.17.0 <= v < 0.18.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }


### PR DESCRIPTION
This updates the package to support Elm 0.18. There were lots of changes
to the `elm-lang/http` package, including turning `Request a` into an
opaque type, removing various `Settings` and merging the rest into
`Request a`, renaming/modifying `RawError` to `Error`, and renaming helper
functions.

The major changes in HttpBuilder are modified types for `Request a`,
`BodyReader a`, `Settings`, & `Error`, the removal of `withMimeType`,
and an additional argument to `withStringBody`(representing the body's
Content-Type).

* Add a `toRequestRecord` function for converting HttpBuilders into the
  record required for `Http.request`.
* Add the non-exposed `decodeResponse` & `fromResponse` functions for
  converting a `Http.Response` into a `Response`.
* Add the non-exposed `parseError` function for converting an 
  `Error String` into a `Error a`, while allowing status codes of 0 to return
  a `Response b`.

* Modify `withStringBody` so that it takes the MIME type as the first
  argument.
* Modify `withMultipartBody` so that it takes a list of `Http.Part`s as
  the first argument.
* Modify `withUrlEncodedBody` so that it includes a `Content-Type`
  header of `application/x-www-form-urlencoded`.
* Modify the `Error a` type to mirror the `Http.Error` type, except with
  `Response a` types instead of `Http.Response String`s.
* Modify the `BodyReader a` type alias to take a `String` instead of an
  `Http.Value`, for use with `Http.expectStringResponse`. Modify
  `stringReader` & `jsonReader` to match the new `BodyReader a` type.

* Remove `withMimeType` since `Http` no longer exposes
  `desiredResponseType`.
* Remove the non-exposed `responseFromRaw` & `handleResponse` functions.

* Replace the `Request` type alias with a record since `Http.Request` is
  now an opaque type. `Request` is now parameterized over the expected
  `Response` type.
* Replace the `Settings` type alias with a record exposing the available
  settings in `Http`.
* Rewrite the `url` function since `Http.url` is no longer exposed.

* Update testing dependencies and switch to the node runner.