### PR TITLE
4.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,5 @@ node_js:
   - "node"
 install:
   - npm install -g elm
+  - npm install -g elm-test
 script: sh ./scripts/test.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,69 @@
+### 4.0.0
+
+A lot has happened since 3.0.0! The API is smaller, and more focused and I'm
+excited about that. In particular, `BodyReader` and its friends have been
+removed. Since this is the official upgrade for Elm 0.18, the new
+`elm-lang/http` package has a lot of influence. The new `Http` package includes
+a much more cohesive experience for declaring expectations of response bodies.
+[See the `Http.Expect` type in `elm-lang/http`](http://package.elm-lang.org/packages/elm-lang/http/1.0.0/Http#Expect).
+This feature is even reminiscent of `BodyReader`!
+
+Since we have this as a part of the platform now, all of the `BodyReader`-
+related features are gone. For these you'll just "use the platform", as they
+say, and make use of `withExpect` in your builder pipelines. In the future
+we may include fancier, custom `Expect` formulations for your convenience.
+
+Secondly, you'll now have the option to convert a `RequestBuilder a` into an
+`Http.Request a` or send it directly using `HttpBuilder.send`, which has the
+same signature as `Http.send`. This helps to keep your builder pipelines clean
+while also leaving you the option to get out an `Http.Request` if you need.
+
+Long story short, `HttpBuilder` is _just_ about building requests, just like
+when it started out. The platform covers the rest.
+
+Here's the list of all changes:
+
+#### Removals
+- `url`: use `withQueryParams` instead to add query params to your url
+- `withBody`: use one of the more specific `with*Body` functions instead
+- `withMultipartBody`: string multipart bodies are the only type supported by
+  `elm-lang/http` currently, sojust use `withMultipartStringBody` instead
+- `withMimeType`: the first parameter to `withStringBody` will set your MIME
+  type automatically. Alternatively, set a header with `withHeader`
+- `withCacheBuster`: since we're giving up control of the send process, we can't
+  chain on a `Task` to get the current time
+- `withZeroStatusAllowed`: we don't control the send process. You can handle
+  this yourself under the `Http.BadStatus` error when you deal with errors in
+  your send msg tagger.
+- `BodyReader`: see intro
+- `stringReader`: see intro
+- `jsonReader`: see intro
+- `unitReader`: see intro
+- `Error`: since we don't control the send process we don't need this
+- `Response`: same as `Error`
+- `toSettings`: `Http.Settings` doesn't exist anymore, it was moved under
+  `Http.Request`
+- `Request`: since we expect you'll need to import `Http` now anyway, you can
+  just import this from `Http`
+- `Settings`: see `toSettings`
+
+
+#### Breaking Changes
+- `RequestBuilder` -> `RequestBuilder a`, where the type parameter is the
+  expected type of the returned payload.
+- `get`, `post`, etc. return `RequestBuilder ()`. The default is to make no
+  attempt to decode anything, so it is `()`. You can use `withExpect` to attach
+  an `Http.Expect MyType`, which will turn it into a `RequestBuilder MyType`.
+- `toRequest` returns an `Http.Request a`
+- `send` wraps `Http.send`, [read up on it to see how it works](http://package.elm-lang.org/packages/elm-lang/http/1.0.0/Http#send).
+
+
+#### Additions
+- `withExpect`: attach an `Http.Expect` to the request
+- `withQueryParams`: decorate the URL with query params
+
+A sincere thank you to @evancz, @rtfeldman, @bogdanp, and @knewter for time and
+discussions that helped me make the decisions that led to these changes!
+
+And a shoutout to @prikhi for taking the time to update the existing API for
+0.18 and publishing it as [priki/elm-http-builder](http://package.elm-lang.org/packages/prikhi/elm-http-builder/latest).

--- a/README.md
+++ b/README.md
@@ -5,27 +5,13 @@
 
 Chainable functions for building HTTP requests.
 
-**Need help? Join the #http channel in the [Elm Slack](https://elmlang.herokuapp.com)!**
+**Need help? Join the #http-builder channel in the [Elm Slack](https://elmlang.herokuapp.com)!**
 
 
 > Thanks to @fredcy, @rileylark, and @etaque for the original discussion of the
   API, and to @knewter for pairing and discussion on the 0.18 upgrade.
 
 ## Example
-
-In this example, we expect a successful response to be JSON array of strings,
-like:
-
-```json
-["hello", "world", "this", "is", "the", "best", "json", "ever"]
-```
-
-and an error response might have a body which just includes text, such as the
-following for a 404 error:
-
-```json
-Not Found.
-```
 
 ```elm
 import Time
@@ -50,10 +36,15 @@ handleRequestComplete : Result Http.Error (List String) -> Msg
 handleRequestComplete result =
     -- Handle the result
 
-
+{-| addItem will send a post request to
+`"http://example.com/api/items?hello=world"` with the given JSON body, a
+custom header, and cookies included. It'll try to decode with `itemsDecoder`.
+-}
 addItem : String -> Cmd Msg
 addItem item =
     HttpBuilder.post "http://example.com/api/items"
+        |> withQueryParams [ ("hello", "world") ]
+        |> withHeader "X-My-Header" "Some Header Value"
         |> withJsonBody (itemEncoder item)
         |> withTimeout (10 * Time.second)
         |> withExpect (Http.expectJson itemsDecoder)
@@ -63,7 +54,7 @@ addItem item =
 
 ## Contributing
 
- I'm happy to receive any feedback and ideas for about additional features. Any
+I'm happy to receive any feedback and ideas for about additional features. Any
 input and pull requests are very welcome and encouraged. If you'd like to help
 or have ideas, get in touch with me at @luke_dot_js on Twitter or @luke in the
 elmlang Slack!

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 [![ICARE](https://icarebadge.com/ICARE-white.png)](https://icarebadge.com)
 [![Build Status](https://travis-ci.org/lukewestby/elm-http-builder.svg?branch=master)](https://travis-ci.org/lukewestby/elm-http-builder)
 
-Chainable functions for building HTTP requests and composable functions for handling responses.
+Chainable functions for building HTTP requests.
 
 **Need help? Join the #http channel in the [Elm Slack](https://elmlang.herokuapp.com)!**
 
 
 > Thanks to @fredcy, @rileylark, and @etaque for the original discussion of the
-  API
+  API, and to @knewter for pairing and discussion on the 0.18 upgrade.
 
 ## Example
 
@@ -27,13 +27,9 @@ following for a 404 error:
 Not Found.
 ```
 
-We'll use `HttpBuilder.jsonReader` and a `Json.Decode.Decoder` to parse the
-successful response body and `HttpBuilder.stringReader` to accept a string
-body on error without trying to parse JSON.
-
 ```elm
-import Task exposing (Task)
 import Time
+import Http
 import HttpBuilder exposing (..)
 import Json.Decode as Decode
 import Json.Encode as Encode
@@ -41,23 +37,28 @@ import Json.Encode as Encode
 
 itemsDecoder : Decode.Decoder (List String)
 itemsDecoder =
-  Decode.list Decode.string
+    Decode.list Decode.string
 
 
 itemEncoder : String -> Encode.Value
 itemEncoder item =
-  Encode.object
-    [ ("item", Encode.string item) ]
+    Encode.object
+        [ ("item", Encode.string item) ]
 
 
-addItem : String -> Task (HttpBuilder.Error String) (HttpBuilder.Response (List String))
+handleRequestComplete : Result Http.Error (List String) -> Msg
+handleRequestComplete result =
+    -- Handle the result
+
+
+addItem : String -> Cmd Msg
 addItem item =
-  HttpBuilder.post "http://example.com/api/items"
-    |> withJsonBody (itemEncoder item)
-    |> withHeader "Content-Type" "application/json"
-    |> withTimeout (10 * Time.second)
-    |> withCredentials
-    |> send (jsonReader itemsDecoder) stringReader
+    HttpBuilder.post "http://example.com/api/items"
+        |> withJsonBody (itemEncoder item)
+        |> withTimeout (10 * Time.second)
+        |> withExpect (Http.expectJson itemsDecoder)
+        |> withCredentials
+        |> send handleRequestComplete
 ```
 
 ## Contributing

--- a/elm-package.json
+++ b/elm-package.json
@@ -10,8 +10,8 @@
         "HttpBuilder"
     ],
     "dependencies": {
-        "elm-lang/core": "4.0.0 <= v < 5.0.0",
-        "evancz/elm-http": "3.0.1 <= v < 4.0.0"
+        "elm-lang/core": "5.0.0 <= v < 6.0.0",
+        "elm-lang/http": "1.0.0 <= v < 2.0.0"
     },
-    "elm-version": "0.17.0 <= v < 0.18.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.0.0",
+    "version": "4.0.0",
     "summary": "Extra functions for more easily building HTTP requests",
     "repository": "https://github.com/lukewestby/elm-http-builder.git",
     "license": "MIT",

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,6 +1,6 @@
 {
     "version": "3.0.0",
-    "summary": "Extra functions for more easily building and handling Http requests",
+    "summary": "Extra functions for more easily building HTTP requests",
     "repository": "https://github.com/lukewestby/elm-http-builder.git",
     "license": "MIT",
     "source-directories": [

--- a/scripts/unit_tests.sh
+++ b/scripts/unit_tests.sh
@@ -1,4 +1,3 @@
-cd ./tests/unit;
+cd ./tests/unit
 elm-package install -y
-elm-make ./TestRunner.elm --output ./tests.js;
-node ./tests.js;
+elm-test ./Main.elm

--- a/src/HttpBuilder.elm
+++ b/src/HttpBuilder.elm
@@ -1,7 +1,6 @@
 module HttpBuilder
     exposing
         ( RequestBuilder
-        , url
         , get
         , post
         , put
@@ -12,53 +11,28 @@ module HttpBuilder
         , head
         , withHeader
         , withHeaders
-        , withBody
         , withStringBody
         , withJsonBody
-        , withMultipartBody
         , withMultipartStringBody
         , withUrlEncodedBody
         , withTimeout
-        , withMimeType
         , withCredentials
-        , withCacheBuster
-        , withZeroStatusAllowed
-        , send
-        , BodyReader
-        , stringReader
-        , jsonReader
-        , unitReader
-        , Error(..)
-        , Response
+        , withQueryParams
         , toRequest
-        , toSettings
-        , Request
-        , Settings
+        , send
         )
 
 {-| Extra helpers for more easily building Http requests that require greater
 configuration than what is provided by `elm-http` out of the box.
 
-# Send a request
-@docs send
-
 # Start a request
-@docs RequestBuilder, url, get, post, put, patch, delete, options, trace, head
+@docs RequestBuilder, get, post, put, patch, delete, options, trace, head
 
 # Configure request properties
-@docs withHeader, withHeaders, withBody, withStringBody, withJsonBody, withMultipartBody, withMultipartStringBody, withUrlEncodedBody
+@docs withHeader, withHeaders, withStringBody, withJsonBody, withMultipartStringBody, withUrlEncodedBody, withTimeout, withCredentials, withQueryParams
 
-# Configure settings
-@docs withTimeout, withMimeType, withCredentials
-
-# Custom configurations
-@docs withCacheBuster, withZeroStatusAllowed
-
-# Parse the response
-@docs BodyReader, stringReader, jsonReader, unitReader, Error, Response
-
-# Inspect the request
-@docs toRequest, toSettings, Request, Settings
+# Make the request
+@docs toRequest, send
 -}
 
 -- where
@@ -67,158 +41,120 @@ import String
 import Task exposing (Task)
 import Maybe exposing (Maybe(..))
 import Time exposing (Time)
-import Json.Decode as JsonDecode
-import Json.Encode as JsonEncode
+import Json.Decode as Decode
+import Json.Encode as Encode
 import Dict exposing (Dict)
 import Result exposing (Result(Ok, Err))
-import Http exposing (Value(Text), RawError(..))
+import Http
 
 
-{-| Re-export `Http.Request`
--}
-type alias Request =
-    Http.Request
-
-
-{-| Re-export `Http.Settings`
--}
-type alias Settings =
-    Http.Settings
-
-
-type alias Internals =
-    { cacheBuster : Bool
-    , zeroStatusAllowed : Bool
+type alias RequestDetails a =
+    { method : String
+    , headers : List Http.Header
+    , url : String
+    , body : Http.Body
+    , expect : Http.Expect a
+    , timeout : Maybe Time
+    , withCredentials : Bool
+    , queryParams : List ( String, String )
     }
-
-
-defaultInternals : Internals
-defaultInternals =
-    { cacheBuster = False
-    , zeroStatusAllowed = False
-    }
-
-
-{-| Construct a url using String, String key value pairs for the query string.
-See `Http.url`.
-
-    googleUrl =
-        url "https://google.com" [("q", "elm")]
--}
-url : String -> List ( String, String ) -> String
-url =
-    Http.url
 
 
 {-| A type for chaining request configuration
 -}
-type RequestBuilder
-    = RequestBuilder Http.Request Http.Settings Internals
+type RequestBuilder a
+    = RequestBuilder (RequestDetails a)
 
 
-requestWithVerbAndUrl : String -> String -> RequestBuilder
-requestWithVerbAndUrl verb url =
+requestWithMethodAndUrl : String -> String -> RequestBuilder ()
+requestWithMethodAndUrl method url =
     RequestBuilder
-        { verb = verb
+        { method = method
         , url = url
         , headers = []
-        , body = Http.empty
+        , body = Http.emptyBody
+        , expect = Http.expectStringResponse (\_ -> Ok ())
+        , timeout = Nothing
+        , withCredentials = False
+        , queryParams = []
         }
-        Http.defaultSettings
-        defaultInternals
 
 
-mapRequest : (Http.Request -> Http.Request) -> RequestBuilder -> RequestBuilder
-mapRequest updater (RequestBuilder request settings internals) =
-    RequestBuilder (updater request)
-        (settings)
-        (internals)
-
-
-mapSettings : (Http.Settings -> Http.Settings) -> RequestBuilder -> RequestBuilder
-mapSettings updater (RequestBuilder request settings internals) =
-    RequestBuilder (request)
-        (updater settings)
-        (internals)
-
-
-mapInternals : (Internals -> Internals) -> RequestBuilder -> RequestBuilder
-mapInternals updater (RequestBuilder request settings internals) =
-    RequestBuilder (request)
-        (settings)
-        (updater internals)
+map : (RequestDetails a -> RequestDetails b) -> RequestBuilder a -> RequestBuilder b
+map fn (RequestBuilder details) =
+    RequestBuilder <| fn details
 
 
 {-| Start building a GET request with a given URL
 
     get "https://example.com/api/items/1"
 -}
-get : String -> RequestBuilder
+get : String -> RequestBuilder ()
 get =
-    requestWithVerbAndUrl "GET"
+    requestWithMethodAndUrl "GET"
 
 
 {-| Start building a POST request with a given URL
 
     post "https://example.com/api/items"
 -}
-post : String -> RequestBuilder
+post : String -> RequestBuilder ()
 post =
-    requestWithVerbAndUrl "POST"
+    requestWithMethodAndUrl "POST"
 
 
 {-| Start building a PUT request with a given URL
 
     put "https://example.com/api/items/1"
 -}
-put : String -> RequestBuilder
+put : String -> RequestBuilder ()
 put =
-    requestWithVerbAndUrl "PUT"
+    requestWithMethodAndUrl "PUT"
 
 
 {-| Start building a PATCH request with a given URL
 
     patch "https://example.com/api/items/1"
 -}
-patch : String -> RequestBuilder
+patch : String -> RequestBuilder ()
 patch =
-    requestWithVerbAndUrl "PATCH"
+    requestWithMethodAndUrl "PATCH"
 
 
 {-| Start building a DELETE request with a given URL
 
     delete "https://example.com/api/items/1"
 -}
-delete : String -> RequestBuilder
+delete : String -> RequestBuilder ()
 delete =
-    requestWithVerbAndUrl "DELETE"
+    requestWithMethodAndUrl "DELETE"
 
 
 {-| Start building a OPTIONS request with a given URL
 
     options "https://example.com/api/items/1"
 -}
-options : String -> RequestBuilder
+options : String -> RequestBuilder ()
 options =
-    requestWithVerbAndUrl "OPTIONS"
+    requestWithMethodAndUrl "OPTIONS"
 
 
 {-| Start building a TRACE request with a given URL
 
     trace "https://example.com/api/items/1"
 -}
-trace : String -> RequestBuilder
+trace : String -> RequestBuilder ()
 trace =
-    requestWithVerbAndUrl "TRACE"
+    requestWithMethodAndUrl "TRACE"
 
 
 {-| Start building a HEAD request with a given URL
 
     head "https://example.com/api/items/1"
 -}
-head : String -> RequestBuilder
+head : String -> RequestBuilder ()
 head =
-    requestWithVerbAndUrl "HEAD"
+    requestWithMethodAndUrl "HEAD"
 
 
 {-| Add a single header to a request
@@ -226,9 +162,9 @@ head =
     get "https://example.com/api/items/1"
         |> withHeader "Content-Type" "application/json"
 -}
-withHeader : String -> String -> RequestBuilder -> RequestBuilder
+withHeader : String -> String -> RequestBuilder a -> RequestBuilder a
 withHeader key value =
-    mapRequest <| \request -> { request | headers = ( key, value ) :: request.headers }
+    map <| \details -> { details | headers = (Http.header key value) :: details.headers }
 
 
 {-| Add many headers to a request
@@ -236,31 +172,28 @@ withHeader key value =
     get "https://example.com/api/items/1"
         |> withHeaders [("Content-Type", "application/json"), ("Accept", "application/json")]
 -}
-withHeaders : List ( String, String ) -> RequestBuilder -> RequestBuilder
-withHeaders headers =
-    mapRequest <| \request -> { request | headers = headers ++ request.headers }
+withHeaders : List ( String, String ) -> RequestBuilder a -> RequestBuilder a
+withHeaders headerPairs =
+    map
+        <| \details ->
+            { details
+                | headers = (List.map (uncurry Http.header) headerPairs) ++ details.headers
+            }
 
 
-{-| Add a body to a request for requests that allow bodies.
-
-    post "https://example.com/api/items/1"
-        |> withHeader "Content-Type" "application/json"
-        |> withBody (Http.string """{ "sortBy": "coolness", "take": 10 }""")
--}
-withBody : Http.Body -> RequestBuilder -> RequestBuilder
+withBody : Http.Body -> RequestBuilder a -> RequestBuilder a
 withBody body =
-    mapRequest <| \request -> { request | body = body }
+    map <| \details -> { details | body = body }
 
 
 {-| Convenience function for adding a string body to a request
 
     post "https://example.com/api/items/1"
-        |> withHeader "Content-Type" "application/json"
-        |> withStringBody """{ "sortBy": "coolness", "take": 10 }"""
+        |> withStringBody "application/json" """{ "sortBy": "coolness", "take": 10 }"""
 -}
-withStringBody : String -> RequestBuilder -> RequestBuilder
-withStringBody =
-    Http.string >> withBody
+withStringBody : String -> String -> RequestBuilder a -> RequestBuilder a
+withStringBody contentType value =
+    withBody <| Http.stringBody contentType value
 
 
 {-| Convenience function for adding a JSON body to a request
@@ -271,22 +204,11 @@ withStringBody =
         ]
 
     post "https://example.com/api/items/1"
-        |> withHeader "Content-Type" "application/json"
         |> withJsonBody params
 -}
-withJsonBody : JsonEncode.Value -> RequestBuilder -> RequestBuilder
-withJsonBody =
-    (JsonEncode.encode 0) >> withStringBody
-
-
-{-| Convenience function for adding a multiplart body to a request
-
-    post "https://example.com/api/items/1"
-        |> withMultipartBody [Http.stringData "user" (JS.encode user)]
--}
-withMultipartBody : List Http.Data -> RequestBuilder -> RequestBuilder
-withMultipartBody =
-    Http.multipart >> withBody
+withJsonBody : Encode.Value -> RequestBuilder a -> RequestBuilder a
+withJsonBody value =
+    withBody <| Http.jsonBody value
 
 
 {-| Convience function for adding multipart bodies composed of String, String
@@ -297,20 +219,23 @@ your type signatures.
     post "https://example.com/api/items/1"
         |> withMultipartStringBody [("user", JS.encode user)]
 -}
-withMultipartStringBody : List ( String, String ) -> RequestBuilder -> RequestBuilder
-withMultipartStringBody =
-    List.map (\( key, value ) -> Http.stringData key value)
-        >> withMultipartBody
+withMultipartStringBody : List ( String, String ) -> RequestBuilder a -> RequestBuilder a
+withMultipartStringBody partPairs =
+    map
+        <| \details ->
+            { details
+                | body = Http.multipartBody <| List.map (uncurry Http.stringPart) partPairs
+            }
 
 
 {-| Convenience function for adding url encoded bodies
 
     post "https://example.com/api/whatever"
-        |> withUrlEncodedBody [("user", "Evan"), ("pwd", "secret")]
+        |> withUrlEncodedBody [("user", "Luke"), ("pwd", "secret")]
 -}
-withUrlEncodedBody : List ( String, String ) -> RequestBuilder -> RequestBuilder
+withUrlEncodedBody : List ( String, String ) -> RequestBuilder a -> RequestBuilder a
 withUrlEncodedBody =
-    joinUrlEncoded >> withStringBody
+    joinUrlEncoded >> withStringBody "application/x-www-form-urlencoded"
 
 
 {-| Set the `timeout` setting on the request
@@ -318,20 +243,9 @@ withUrlEncodedBody =
     get "https://example.com/api/items/1"
         |> withTimeout (10 * Time.second)
 -}
-withTimeout : Time -> RequestBuilder -> RequestBuilder
+withTimeout : Time -> RequestBuilder a -> RequestBuilder a
 withTimeout timeout =
-    mapSettings <| \settings -> { settings | timeout = timeout }
-
-
-{-| Set the desired type of the response for the request, works via
-[`XMLHttpRequest#overrideMimeType()`](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest#overrideMimeType())
-
-    get "https://example.com/api/items/1"
-        |> withMimeType (onProgressHandler)
--}
-withMimeType : String -> RequestBuilder -> RequestBuilder
-withMimeType mimeType =
-    mapSettings <| \settings -> { settings | desiredResponseType = Just mimeType }
+    map <| \details -> { details | timeout = Just timeout }
 
 
 {-| Set the `withCredentials` flag on the request to True. Works via
@@ -340,194 +254,64 @@ withMimeType mimeType =
     get "https://example.com/api/items/1"
         |> withCredentials
 -}
-withCredentials : RequestBuilder -> RequestBuilder
+withCredentials : RequestBuilder a -> RequestBuilder a
 withCredentials =
-    mapSettings <| \settings -> { settings | withCredentials = True }
+    map <| \details -> { details | withCredentials = True }
 
 
-{-| Injects a cache busting url param into the url with the current timestamp as
-the value to prevent the server from caching responses
+{-| Choose an `Expect` for the request
+
     get "https://example.com/api/items/1"
-        |> withCredentials
+        |> withExpect (Http.expectJson itemsDecoder)
 -}
-withCacheBuster : RequestBuilder -> RequestBuilder
-withCacheBuster =
-    mapInternals <| \internals -> { internals | cacheBuster = True }
+withExpect : Http.Expect b -> RequestBuilder a -> RequestBuilder b
+withExpect expect =
+    map <| \details -> { details | expect = expect }
 
 
-{-| Explicitly allows a require for a file:// url with a response status code
-of 0 to pass through successfully. This is a common issue when dealing with
-file:// urls in environments like cordova, and using this function will allow
-you to work around the problem on an opt-in basis.
+{-| Add some query params to the url for the request
+
+    get "https://example.com/api/items/1"
+        |> withQueryParams [("hello", "world"), ("foo", "bar")]
+        |> withQueryParams [("baz", "qux")]
+    -- sends a request to https://example.com/api/items/1?hello=world&foo=bar&baz=qux
 -}
-withZeroStatusAllowed : RequestBuilder -> RequestBuilder
-withZeroStatusAllowed =
-    mapInternals <| \internals -> { internals | zeroStatusAllowed = True }
-
-
-{-| Represents a response from the server, including both a decoded JSON payload
-and basic network information.
--}
-type alias Response a =
-    { data : a
-    , status : Int
-    , statusText : String
-    , headers : Dict String String
-    , url : String
-    }
-
-
-{-| Indicates that _some_ kind of failure occured along the path of making and
-receiving the request. This includes a timeout or network issue, a failure to
-parse the response body, or a status code outside the 200 range. In the case
-that the error is due to a non-2xx response code, the full response is provided
-and the data decoded as JSON using the decoder for errors passed to `send`.
--}
-type Error a
-    = UnexpectedPayload String
-    | NetworkError
-    | Timeout
-    | BadResponse (Response a)
-
-
-{-| A function for transforming raw response bodies into a useful value. Plain
-string and JSON decoding readers are provided, and the string reader can be
-used as a basis for more custom readers. When future Http value types become
-supported matching readers will be added to extract them.
--}
-type alias BodyReader a =
-    Http.Value -> Result String a
-
-
-{-| Attempts to read a raw response body as a plain text string, failing if the
-body is not readable as a string.
--}
-stringReader : BodyReader String
-stringReader value =
-    case value of
-        Text string ->
-            Ok string
-
-        _ ->
-            Err "String reader does not support given body type."
-
-
-{-| Attempts to decode the raw response body with the given
-`Json.Decode.Decoder`, failing if the body is malformed or not readable as a
-string.
--}
-jsonReader : JsonDecode.Decoder a -> BodyReader a
-jsonReader decoder value =
-    case value of
-        Text string ->
-            JsonDecode.decodeString decoder string
-
-        _ ->
-            Err "JSON reader does not support given body type."
-
-
-{-| Totally discards the content of a raw response body and reads nothing,
-returning `()` as the data value. Great for discarding error response bodies if
-they just look like `"Not Found"` or whatever and aren't really useful.
--}
-unitReader : BodyReader ()
-unitReader =
-    always <| Ok ()
-
-
-{-| Once you're finished building up a request, send it with readers for the
-successful response value as well as the server error response value.
-
-    -- In this example a succesful response from the server looks like
-    -- ["string", "string", "string"], and an error body might look like
-    -- "Bad Request" or something similar, such that it is a string that is
-    -- not valid JSON (it would need to look like "\"Bad Request\"" to be
-    -- decodable as JSON).
-
-    successDecoder : Json.Decode.Decoder (List String)
-    successDecoder =
-        Json.Decode.list Json.Decode.string
-
-    get "https://example.com/api/items"
-        |> withHeader "Content-Type" "application/json"
-        |> withTimeout (10 * Time.second)
-        |> send (jsonReader successDecoder) stringReader
--}
-send : BodyReader a -> BodyReader b -> RequestBuilder -> Task (Error b) (Response a)
-send successReader errorReader (RequestBuilder request settings internals) =
-    if internals.cacheBuster then
-        Time.now
-            |> Task.map (appendCacheBusterToUrl request)
-            |> (flip Task.andThen) (sendHelp successReader errorReader internals settings)
-    else
-        sendHelp successReader errorReader internals settings request
-
-
-sendHelp : BodyReader a -> BodyReader b -> Internals -> Settings -> Request -> Task (Error b) (Response a)
-sendHelp successReader errorReader internals settings request =
-    Http.send settings request
-        |> Task.mapError promoteRawError
-        |> (flip Task.andThen) (handleResponse successReader errorReader internals)
-
-
-appendCacheBusterToUrl : Request -> Time -> Request
-appendCacheBusterToUrl request time =
-    { request | url = appendQuery request.url "_" (toString time) }
-
-
-promoteRawError : Http.RawError -> Error a
-promoteRawError rawError =
-    case rawError of
-        RawTimeout ->
-            Timeout
-
-        RawNetworkError ->
-            NetworkError
-
-
-responseFromRaw : BodyReader a -> Http.Response -> Task (Error b) (Response a)
-responseFromRaw reader response =
-    case reader response.value of
-        Ok data ->
-            Task.succeed
-                { data = data
-                , status = response.status
-                , statusText = response.statusText
-                , headers = response.headers
-                , url = response.url
-                }
-
-        Err message ->
-            Task.fail (UnexpectedPayload message)
-
-
-handleResponse : BodyReader a -> BodyReader b -> Internals -> Http.Response -> Task (Error b) (Response a)
-handleResponse successReader errorReader internals response =
-    let
-        isSuccessful =
-            (response.status >= 200 && response.status < 300) || (response.status == 0 && internals.zeroStatusAllowed)
-    in
-        if isSuccessful then
-            responseFromRaw successReader response
-        else
-            responseFromRaw errorReader response
-                |> (flip Task.andThen) (BadResponse >> Task.fail)
+withQueryParams : List ( String, String ) -> RequestBuilder a -> RequestBuilder a
+withQueryParams queryParams =
+    map <| \details -> { details | queryParams = details.queryParams ++ queryParams }
 
 
 {-| Extract the Http.Request component of the builder, for introspection and
 testing
 -}
-toRequest : RequestBuilder -> Request
-toRequest (RequestBuilder request settings internals) =
-    request
+toRequest : RequestBuilder a -> Http.Request a
+toRequest (RequestBuilder details) =
+    let
+        encodedParams =
+            joinUrlEncoded details.queryParams
+
+        fullUrl =
+            if String.isEmpty encodedParams then
+                details.url
+            else
+                details.url ++ "?" ++ encodedParams
+    in
+        Http.request
+            { method = details.method
+            , url = fullUrl
+            , headers = details.headers
+            , body = details.body
+            , expect = details.expect
+            , timeout = details.timeout
+            , withCredentials = details.withCredentials
+            }
 
 
-{-| Extract the Http.Settings component of the builder, for introspection and
-testing
+{-| Send the request using Http.send
 -}
-toSettings : RequestBuilder -> Settings
-toSettings (RequestBuilder request settings internals) =
-    settings
+send : (Result Http.Error a -> msg) -> RequestBuilder a -> Cmd msg
+send tagger builder =
+    Http.send tagger <| toRequest builder
 
 
 joinUrlEncoded : List ( String, String ) -> String
@@ -542,17 +326,9 @@ queryPair ( key, value ) =
 
 queryEscape : String -> String
 queryEscape =
-    Http.uriEncode >> replace "%20" "+"
+    Http.encodeUri >> replace "%20" "+"
 
 
 replace : String -> String -> String -> String
 replace old new =
     String.split old >> String.join new
-
-
-appendQuery : String -> String -> String -> String
-appendQuery url key value =
-    if String.contains "?" url then
-        url ++ "&" ++ key ++ "=" ++ value
-    else
-        url ++ "?" ++ key ++ "=" ++ value

--- a/src/HttpBuilder.elm
+++ b/src/HttpBuilder.elm
@@ -18,6 +18,7 @@ module HttpBuilder
         , withTimeout
         , withCredentials
         , withQueryParams
+        , withExpect
         , toRequest
         , send
         )

--- a/tests/unit/Main.elm
+++ b/tests/unit/Main.elm
@@ -1,0 +1,14 @@
+port module Main exposing (..)
+
+import Test
+import Test.Runner.Node as Runner exposing (TestProgram)
+import Tests
+import Json.Encode exposing (Value)
+
+
+port emit : ( String, Value ) -> Cmd msg
+
+
+main : TestProgram
+main =
+    Runner.run emit Tests.all

--- a/tests/unit/TestRunner.elm
+++ b/tests/unit/TestRunner.elm
@@ -1,9 +1,0 @@
-module Main exposing (..)
-
-import ElmTest exposing (..)
-import Tests
-
-
-main : Program Never
-main =
-    runSuite Tests.all

--- a/tests/unit/elm-package.json
+++ b/tests/unit/elm-package.json
@@ -10,9 +10,10 @@
     "exposed-modules": [],
     "native-modules": true,
     "dependencies": {
-        "elm-community/elm-test": "1.1.0 <= v < 2.0.0",
-        "elm-lang/core": "4.0.0 <= v < 5.0.0",
-        "evancz/elm-http": "3.0.1 <= v < 4.0.0"
+        "elm-community/elm-test": "3.0.0 <= v < 4.0.0",
+        "elm-lang/core": "5.0.0 <= v < 6.0.0",
+        "elm-lang/http": "1.0.0 <= v < 2.0.0",
+        "rtfeldman/node-test-runner": "3.0.0 <= v < 4.0.0"
     },
-    "elm-version": "0.17.0 <= v < 0.18.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }


### PR DESCRIPTION
A lot has happened since 3.0.0! The API is smaller, and more focused and I'm
excited about that. In particular, `BodyReader` and its friends have been
removed. Since this is the official upgrade for Elm 0.18, the new
`elm-lang/http` package has a lot of influence. The new `Http` package includes
a much more cohesive experience for declaring expectations of response bodies.
[See the `Http.Expect` type in `elm-lang/http`](http://package.elm-lang.org/packages/elm-lang/http/1.0.0/Http#Expect).
This feature is even reminiscent of `BodyReader`!

Since we have this as a part of the platform now, all of the `BodyReader`-
related features are gone. For these you'll just "use the platform", as they
say, and make use of `withExpect` in your builder pipelines. In the future
we may include fancier, custom `Expect` formulations for your convenience.

Secondly, you'll now have the option to convert a `RequestBuilder a` into an
`Http.Request a` or send it directly using `HttpBuilder.send`, which has the
same signature as `Http.send`. This helps to keep your builder pipelines clean
while also leaving you the option to get out an `Http.Request` if you need.

Long story short, `HttpBuilder` is _just_ about building requests, just like
when it started out. The platform covers the rest.

Here's the list of all changes:

#### Removals
- `url`: use `withQueryParams` instead to add query params to your url
- `withBody`: use one of the more specific `with*Body` functions instead
- `withMultipartBody`: string multipart bodies are the only type supported by
  `elm-lang/http` currently, sojust use `withMultipartStringBody` instead
- `withMimeType`: the first parameter to `withStringBody` will set your MIME
  type automatically. Alternatively, set a header with `withHeader`
- `withCacheBuster`: since we're giving up control of the send process, we can't
  chain on a `Task` to get the current time
- `withZeroStatusAllowed`: we don't control the send process. You can handle
  this yourself under the `Http.BadStatus` error when you deal with errors in
  your send msg tagger.
- `BodyReader`: see intro
- `stringReader`: see intro
- `jsonReader`: see intro
- `unitReader`: see intro
- `Error`: since we don't control the send process we don't need this
- `Response`: same as `Error`
- `toSettings`: `Http.Settings` doesn't exist anymore, it was moved under
  `Http.Request`
- `Request`: since we expect you'll need to import `Http` now anyway, you can
  just import this from `Http`
- `Settings`: see `toSettings`


#### Breaking Changes
- `RequestBuilder` -> `RequestBuilder a`, where the type parameter is the
  expected type of the returned payload.
- `get`, `post`, etc. return `RequestBuilder ()`. The default is to make no
  attempt to decode anything, so it is `()`. You can use `withExpect` to attach
  an `Http.Expect MyType`, which will turn it into a `RequestBuilder MyType`.
- `toRequest` returns an `Http.Request a`
- `send` wraps `Http.send`, [read up on it to see how it works](http://package.elm-lang.org/packages/elm-lang/http/1.0.0/Http#send).


#### Additions
- `withExpect`: attach an `Http.Expect` to the request
- `withQueryParams`: decorate the URL with query params

A sincere thank you to @evancz, @rtfeldman, @bogdanp, and @knewter for time and
discussions that helped me make the decisions that led to these changes!

And a shoutout to @prikhi for taking the time to update the existing API for
0.18 and publishing it as [priki/elm-http-builder](http://package.elm-lang.org/packages/prikhi/elm-http-builder/latest).
