### PR TITLE
Fix formatting for withBody docs

### DIFF
--- a/src/HttpBuilder.elm
+++ b/src/HttpBuilder.elm
@@ -174,6 +174,7 @@ withHeaders headerPairs builder =
 
 
 {-| Add an Http.Body to the request
+
     post "https://example.com/api/save-text"
         |> withBody (Http.stringBody "text/plain" "Hello!")
 -}


### PR DESCRIPTION
The example in the `withBody` function is wrongly formatted. 
![image](https://cloud.githubusercontent.com/assets/3721994/26629777/9d5eadb6-460c-11e7-8f3a-ee9e5a25321c.png)

This makes the `withBody` format like the rest of the examples.