### PR TITLE
Add withExpectJson and withExpectString helper functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ node_js:
   - "node"
 install:
   - npm install -g elm
-  - npm install -g elm-test
+  - npm install -g elm-test@0.18.0
 script: sh ./scripts/test.sh

--- a/src/HttpBuilder.elm
+++ b/src/HttpBuilder.elm
@@ -269,7 +269,7 @@ withExpect expect builder =
 -}
 withExpectJson : Decoder b -> RequestBuilder a -> RequestBuilder b
 withExpectJson decoder builder =
-    { builder | expect = (Http.expectJson decoder) }
+    { builder | expect = Http.expectJson decoder }
 
 
 {-| Choose a String `Expect` for the request
@@ -279,7 +279,7 @@ withExpectJson decoder builder =
 -}
 withExpectString : RequestBuilder a -> RequestBuilder String
 withExpectString builder =
-    { builder | expect = (Http.expectString) }
+    { builder | expect = Http.expectString }
 
 
 {-| Add some query params to the url for the request

--- a/src/HttpBuilder.elm
+++ b/src/HttpBuilder.elm
@@ -46,6 +46,7 @@ import Task exposing (Task)
 import Maybe exposing (Maybe(..))
 import Time exposing (Time)
 import Json.Encode as Encode
+import Json.Decode exposing (Decoder)
 import Result exposing (Result(Ok, Err))
 import Http
 
@@ -259,6 +260,26 @@ withCredentials builder =
 withExpect : Http.Expect b -> RequestBuilder a -> RequestBuilder b
 withExpect expect builder =
     { builder | expect = expect }
+
+
+{-| Choose a Json `Expect` for the request
+
+    get "https://example.com/api/items/1"
+        |> withExpectJson itemsDecoder
+-}
+withExpectJson : Decoder b -> RequestBuilder a -> RequestBuilder b
+withExpectJson decoder builder =
+    { builder | expect = (Http.expectJson decoder) }
+
+
+{-| Choose a String `Expect` for the request
+
+    get "https://example.com/api/items/1"
+        |> withExpectString
+-}
+withExpectString : RequestBuilder a -> RequestBuilder String
+withExpectString builder =
+    { builder | expect = (Http.expectString) }
 
 
 {-| Add some query params to the url for the request


### PR DESCRIPTION
Since the pattern `withExpect (Http.expectJson a)` seems to be pretty common, I created a new `withExpectJson` function that captures this behavior.  I also created a `withExpectString` that captures `withExpect Http.exepectString`.