### PR TITLE
Fix typo in `application/x-www-form-urlencode`

### DIFF
--- a/src/HttpBuilder.elm
+++ b/src/HttpBuilder.elm
@@ -255,7 +255,7 @@ withUrlEncodedBody parts =
                 encoded
     in
     withStringBody
-        "application/x-www-form-urlencode"
+        "application/x-www-form-urlencoded"
         trimmedQuestionMark
 
 


### PR DESCRIPTION
Change `application/x-www-form-urlencode` to correct one `application/x-www-form-urlencoded`